### PR TITLE
43 breed refactor

### DIFF
--- a/src/Creature.py
+++ b/src/Creature.py
@@ -86,7 +86,7 @@ class Creature:
         self.traits = random_traits
 
 
-    def outputCreature(self):
+    def outputCreature(self,output_all = False):
         """Returns a tuple containing a formatted string with details about the
         creature and the correct image for the bot to display based on the creature's age.
         The amount of information returned in the string also varies based on creature's age."""
@@ -99,9 +99,9 @@ class Creature:
                 f"**Create Date:** {datetime.strftime(self.createDate,Constants.DATEONLYFORMAT)}\n"\
                 f"**Generation:** {self.generation}\n"\
                  "**---Traits---**\n"
-        if age.days <= 7 and self.generation != 0:
+        if age.days <= 7 and self.generation != 0 and not output_all:
             image_link = self.imageLink_nb
-        elif age.days <= 14 and self.generation != 0:
+        elif age.days <= 14 and self.generation != 0 and not output_all:
             output += f"**Main Horn**: {self.traits['MAIN_HORN']}\n"
             image_link = self.imageLink_pup
         else:

--- a/src/Ticket.py
+++ b/src/Ticket.py
@@ -35,6 +35,7 @@ class Ticket:
     def output_ticket(self):
         """returns a formatted string with ticket details"""
         return f"Ticket #{self.id} - {self.name}\n"\
+              f"Requesting User: <@{self.requestor.userId}>\n"\
               f"Open Date: {self.ticket_date}\n"\
               f"Status: {self.status}\n"\
               f"Parent A: {self.creature_a.creatureId}-{self.creature_a.name}\n"\

--- a/src/Ticket.py
+++ b/src/Ticket.py
@@ -53,7 +53,7 @@ class Ticket:
         """Outputs a detailed ticket for the #breeding-tickets channel"""
         output=self.output_ticket()+"\n------------\n"
         for pup in self.pups:
-            output+=pup.outputCreature()
+            output+=pup.outputCreature(output_all=True)[0]
             output+="----------------------\n"
         return output
 


### PR DESCRIPTION
- Split .breed into 3 methods (enact_breed, pend_breed, and create_breeding_ticket).  Refactored .accept and .adminBreed to use new methods.
- Updated Ticket.output_ticket() to use the new format of Creature.outputCreature().
- Added argument output_all (defaults to False) to Creature.outputCreature().  Overrides the default behavior of restricting information about the creature based on age.