### PR TITLE
50 allow makerandomcreature to create a user defined number of creatures per run

### DIFF
--- a/src/cogs/cog_admin.py
+++ b/src/cogs/cog_admin.py
@@ -54,16 +54,16 @@ class AdminCog(commands.GroupCog, name='Admin Tools', group_name='admin'):
         """Takes in an optional quantity parameter and stores that many creatures in the database
         with randomized traits.  Outputs the creature to the interface after completion."""
         user_id = ctx.message.author.id
+        creatures_to_add = []
         for count in range(1,quantity+1):
             creature_to_add = Creature(f"Random {count}",user_id)
             creature_to_add.randomize_creature()
-            creature_id = database_methods.add_creature_to_db(creature_to_add)
-            if creature_id:
-                creature_to_add.creatureId=creature_id
-                await ctx.send(f"{creature_to_add.name} added to database with ID #{creature_id}")
-                #await ctx.send(creature_to_add.outputCreature()[0])
-            else:
-                await ctx.send("An error occurred adding new creatures to DB")
+            creatures_to_add.append(creature_to_add)
+        returned_ids = database_methods.add_multiple_creatures_to_db(creatures_to_add)
+        output = "The following creatures have been added to the database: "
+        for returned_id in returned_ids:
+            output+= f"{returned_id[0]} "
+        await ctx.send(output)
 
     @commands.command()
     @is_guild_owner_or_bot_admin()

--- a/tests/test_Creature.py
+++ b/tests/test_Creature.py
@@ -75,7 +75,7 @@ def test_get_creature_from_db_that_doesnt_exist(testCreatureAttributes):
 def test_get_parents_from_db():
     test_creature = database_methods.get_creature_from_db(39)
     parents = database_methods.get_parents_from_db(test_creature)
-    correct_parents = [29,27]
+    correct_parents = [27,29]
     parents_returned = [parents[0].creatureId,parents[1].creatureId]
     assert correct_parents == parents_returned
 
@@ -84,4 +84,8 @@ def test_update_creature():
     test_creature = database_methods.get_creature_from_db(57)
     test_creature.name=new_name
     assert database_methods.update_creature(test_creature)
+
+def test_add_multiple_creatures_to_db():
+    creature_list = [Creature('add_multiple',99999),Creature('add_multiple',99999)]
+    assert database_methods.add_multiple_creatures_to_db(creature_list)
     


### PR DESCRIPTION
added add_multiple_creatures_to_db() to permit adding large numbers of creatures to the database in a single push, rather than as individual transactions.  Also refactored .makeRandomCreature() to reduce the number of discord API calls to 1 no matter how many creatures were created.